### PR TITLE
Add _very initial_ support for 3.0

### DIFF
--- a/bw_file.py
+++ b/bw_file.py
@@ -107,6 +107,12 @@ class BW_File:
 		bytecode.set_string_mode()
 		self.header = bytecode.read_str(40)
 		if self.header[:4] == 'BtWg' and int(self.header[4:40], 16):
+			if self.header[7] == '2':
+				if bytecode.contents_len < 60:
+					return
+				bytecode.reset_pos()
+				self.header = bytecode.read_str(60)
+
 			if self.header[11] == '2' or self.header[11] == '0':
 				bytecode.set_string_mode(self.header[11])
 				self.meta.decode(bytecode)

--- a/bw_file.py
+++ b/bw_file.py
@@ -140,6 +140,13 @@ class BW_File:
 		from pytwig.src.lib import fs
 		fs.write(path, self.serialize().replace('":', '" :'))
 
+	def read_bytes(self, bytes, raw = True, meta_only = False):
+		bytecode = BW_Bytecode().set_contents(bytes)
+		bytecode.raw = raw
+		bytecode.debug_obj = self
+		#self.num_spaces = 0
+		self.decode(bytecode, meta_only = meta_only)
+
 	def read(self, path, raw = True, meta_only = False):
 		from pytwig.src.lib import fs
 		bytecode = BW_Bytecode().set_contents(fs.read_binary(path))


### PR DESCRIPTION
At least for bwpresets from 3.0 Alpha 1 and Beta 1 branches, those saved for The Grid Device have a different header structure.
The first tweak is that the four bytes after BtWg are "0002" and not "0001" (in character form)
The second is that the header "section" is 60 bytes long instead of 40

This is a _very quick_ tweak to allow parsing of these Presets without failing. There's plenty more to be done to support these newer headers and perhaps any features that come with them.
Before the metadata is decoded, I made it check the 8th character, and if it's "2" (the newer value) then it will re-read the header as 60 bytes.
The rest continues as usual and there's no errors when parsing the metadata. Of the bwpresets I've found, I could still parse the contents of one of them but most would still fail